### PR TITLE
fix #147

### DIFF
--- a/src/pocketmine/entity/EnderPearl.php
+++ b/src/pocketmine/entity/EnderPearl.php
@@ -53,7 +53,7 @@ class EnderPearl extends Projectile{
 	}
 
 	public function close(){
-		if ($this->getSpawner() instanceof Player) {
+		if ($this->getSpawner() instanceof Player && $this->level != null) {
 			$this->getSpawner()->teleport($this);
 		}
 		parent::close();


### PR DESCRIPTION
his is due to the fact that the player has thrown a enderpearl, but the world is unloaded and perform close() function, and it will teleport the player to enderpearl, but because it is unloaded world - shows the error
...
