### PR TITLE
Make Player::sendTitle() more universal-plugin friendly

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3424,11 +3424,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
     /**
      * Send a title text or/and with/without a sub title text to a player
      *
-     * @param $title
+     * @param string $title
      * @param string $subtitle
+	 * @param int $fadein
+	 * @param int $duration
+	 * @param int $fadeout
      * @return bool
      */
-	public function sendTitle($title, $subtitle = "", $fadein = 20, $fadeout = 20, $duration = 5){
+	public function sendTitle($title, $subtitle = "", $fadein = 20, $duration = 5, $fadeout = 20){
 		$pk = new SetTitlePacket();
 		$pk->type = SetTitlePacket::TYPE_TITLE;
 		$pk->title = $title;


### PR DESCRIPTION
Slight changes to sendTitle() that benefits plugin developers looking to support PMMP and Tesseract.
## PR Description
This commit only switches the order of parameters in the sendTitle() method. This is so that developers can use the same function regardless of whether there plugin is deployed on PMMP or Tesseract. This will only effect any plugins that currently don't support PMMP. The function is not currently in the master branch of PMMP. but will be soon. Due to how developer-friendly Tesseract is, I believe this is the best place for the commit.

In addition to the above reasoning, it makes more logical sense that the order of parameters be like so:
1) Fade in
2) Duration
3) Fade out

## Have you tested it?
- [X] I have tested it.
- [ ] I have not tested it.
...
