### PR TITLE
Change codename back to ruby

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -76,7 +76,7 @@ namespace pocketmine {
 
     const VERSION = "1.2.1";
     const API_VERSION = "3.0.1";
-    const CODENAME = "CryRuby";
+    const CODENAME = "Ruby";
 
     /*
      * Startup code. Do not look at it, it may harm you.

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -76,7 +76,7 @@ namespace pocketmine {
 
     const VERSION = "1.2.1";
     const API_VERSION = "3.0.1";
-    const CODENAME = "Opal";
+    const CODENAME = "CryRuby";
 
     /*
      * Startup code. Do not look at it, it may harm you.


### PR DESCRIPTION
## PR Description
Changes codename back from RottenApple (.-.), to Opal, now to its original and classic codename Ruby

## Have you tested it?
It changes codename, no need to test

## Any other concerns?
Direct Commits are not working anymore for me, what seems to be the problem with that?