### PR TITLE
Fixed crash when done executing the server

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1382,7 +1382,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
             if ($entity instanceof Arrow and $entity->hadCollision) {
              	$item = Item::get(Item::ARROW, $entity->getPotionId(), 1);
-
+			}
                
 			$add = false;
 			if (!$this->server->allowInventoryCheats and !$this->isCreative()) {		


### PR DESCRIPTION
Also it fixes the build failure on TravisCI.

## PR Description
I have tested Tesseract before this fix is applied and it crashed when the server is done loading and enabling plugins, thus causing the server crash. On line 1385, there is the missing "}" sign at the end of "if ($entity instanceof Arrow and $entity->hadCollision) {" and so were added to prevent server crash.

After a while, I have searched for line # that Crash Dump gave me, but I searched above these lines and found this culprit!

## Have you tested it?
- [x] I have tested it.
- [ ] I have not tested it.
...
